### PR TITLE
Update groupId to use new prefix requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.vaadin.artur</groupId>
+    <groupId>org.vaadin.addons.mycompany</groupId>
     <artifactId>addon-flow</artifactId>
     <version>1.0.0</version>
     <name>Add-on for Vaadin</name>


### PR DESCRIPTION
Maven coordinate policy has been updated. New add-ons have to prefix their Maven group ID with org.vaadin.addons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/addon-starter-flow/183)
<!-- Reviewable:end -->
