### PR TITLE
Update groupId to use new prefix requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.vaadin.artur</groupId>
+    <groupId>org.vaadin.addons.mycompany</groupId>
     <artifactId>addon-flow</artifactId>
     <version>1.0.0</version>
     <name>Add-on for Vaadin</name>

--- a/src/main/java/org/vaadin/addons/mycompany/theaddon/TheAddon.java
+++ b/src/main/java/org/vaadin/addons/mycompany/theaddon/TheAddon.java
@@ -1,4 +1,4 @@
-package org.vaadin.artur.paperslider;
+package org.vaadin.addons.mycompany.theaddon;
 
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;

--- a/src/test/java/org/vaadin/addons/mycompany/theaddon/TestView.java
+++ b/src/test/java/org/vaadin/addons/mycompany/theaddon/TestView.java
@@ -1,4 +1,6 @@
-package org.vaadin.artur.paperslider;
+package org.vaadin.addons.mycompany.theaddon;
+
+import org.vaadin.addons.mycompany.theaddon.TheAddon;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;


### PR DESCRIPTION
Maven coordinate policy has been updated. New add-ons have to prefix their Maven group ID with `org.vaadin.addons`.

