### PR TITLE
Upgrade assembly.xml's assemply tags xmlns versions.

### DIFF
--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
     <id>game-card</id>
 
     <formats>


### PR DESCRIPTION
This should make the Directory build significantly faster, especially on Win machines.

## Description

At least on Windows machines the Directory build might take tens of minutes in the assembly phase. Updating these xmlns seems to fix the issue. (Sorry, for the short description).

