### PR TITLE
feat: execute tests in headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ This deploys demo at http://localhost:8080
 
 To run Integration Tests, execute `mvn verify -Pit,production`.
 
+Tests run by default in `headless` mode, to avoid browser windows to be opened for every test.
+This behaviour is always disabled when running the tests in debug mode in the IDE
+or when running maven with the `-Dmaven.failsafe.debug` sytem property.
+On normal execution, headless mode can be deactivated using the `-Dtest.headless=false` system property.
+
 ## Publishing to Vaadin Directory
 
 You should change the `organization.name` property in `pom.xml` to your own name/organization.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@vaadin/component-base": "24.0.2",
     "@vaadin/confirm-dialog": "24.0.2",
     "@vaadin/context-menu": "24.0.2",
+    "@vaadin/cookie-consent": "24.0.2",
     "@vaadin/custom-field": "24.0.2",
     "@vaadin/date-picker": "24.0.2",
     "@vaadin/date-time-picker": "24.0.2",
@@ -100,6 +101,7 @@
       "@vaadin/component-base": "24.0.2",
       "@vaadin/confirm-dialog": "24.0.2",
       "@vaadin/context-menu": "24.0.2",
+      "@vaadin/cookie-consent": "24.0.2",
       "@vaadin/custom-field": "24.0.2",
       "@vaadin/date-picker": "24.0.2",
       "@vaadin/date-time-picker": "24.0.2",
@@ -168,7 +170,7 @@
       "workbox-core": "6.5.4",
       "workbox-precaching": "6.5.4"
     },
-    "hash": "d61bb38034c1ede6973a0f4a0c9cadce6c8d142cb581a8e68d2c8ec4837164e7"
+    "hash": "a311d5663e35d15b3c49c7cb1eff9bdbc74f80047463d0c6b34cece5d5aa6e68"
   },
   "overrides": {
     "@vaadin/bundles": "$@vaadin/bundles",
@@ -235,6 +237,7 @@
     "@vaadin/multi-select-combo-box": "$@vaadin/multi-select-combo-box",
     "@vaadin/tabsheet": "$@vaadin/tabsheet",
     "@vaadin/tooltip": "$@vaadin/tooltip",
-    "@vaadin/overlay": "$@vaadin/overlay"
+    "@vaadin/overlay": "$@vaadin/overlay",
+    "@vaadin/cookie-consent": "$@vaadin/cookie-consent"
   }
 }

--- a/src/test/java/org/vaadin/addons/mygroup/AbstractViewTest.java
+++ b/src/test/java/org/vaadin/addons/mygroup/AbstractViewTest.java
@@ -1,11 +1,14 @@
 package org.vaadin.addons.mygroup;
 
+import java.lang.management.ManagementFactory;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.testbench.ScreenshotOnFailureRule;
@@ -50,9 +53,24 @@ public abstract class AbstractViewTest extends ParallelTest {
         if (isUsingHub()) {
             super.setup();
         } else {
-            setDriver(TestBench.createDriver(new ChromeDriver()));
+            setDriver(TestBench.createDriver(new ChromeDriver(chromeOptions())));
         }
         getDriver().get(getURL(route));
+    }
+
+
+    protected ChromeOptions chromeOptions() {
+        ChromeOptions options = new ChromeOptions();
+        boolean headless = Boolean.parseBoolean(System.getProperty("test.headless", "true"));
+        if (headless && !isJavaInDebugMode()) {
+            options.addArguments("--headless=new", "--disable-gpu");
+        }
+        return options;
+    }
+
+    static boolean isJavaInDebugMode() {
+        return ManagementFactory.getRuntimeMXBean().getInputArguments()
+                .toString().contains("jdwp");
     }
 
     /**
@@ -70,8 +88,8 @@ public abstract class AbstractViewTest extends ParallelTest {
      * identified by {@code themeClass}. If the the is not found, JUnit
      * assert will fail the test case.
      *
-     * @param element       web element to check for the theme
-     * @param themeClass    theme class (such as {@code Lumo.class}
+     * @param element    web element to check for the theme
+     * @param themeClass theme class (such as {@code Lumo.class}
      */
     protected void assertThemePresentOnElement(
             WebElement element, Class<? extends AbstractTheme> themeClass) {


### PR DESCRIPTION
Prevents browser windows to be opened when executing tests. However, headless mode is always deactivate when running the test in debug mode.
