### PR TITLE
fix: Add missing servlet-api dependency for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
             <groupId>com.vaadin</groupId>
             <!-- Consider limiting the dependencies to flow-server only something, but for most end users depending on vaadin-core is ok -->
             <artifactId>vaadin-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.1.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
             <groupId>com.vaadin</groupId>
             <!-- Consider limiting the dependencies to flow-server only something, but for most end users depending on vaadin-core is ok -->
             <artifactId>vaadin-core</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -279,5 +278,3 @@
         </profile>
     </profiles>
 </project>
-
-


### PR DESCRIPTION
- ~~Set `vaadin-core` scope to `provided` to prevent dependency conflicts
  when the addon is added to consumer projects~~ (cannot set it as provided)
- Add `jakarta.servlet-api` (6.1.0) as `test` dependency to fix compilation
  when `flow-server` does not provide it transitively

In upcoming Vaadin versions, `jakarta.servlet-api` is no longer pulled
transitively (it was coming via `vaadin-testbench` which has been
restructured). This proactively fixes the addon-template so it does not
break when upgrading.

Fixes vaadin/flow#23785